### PR TITLE
Update submodule path, commit reference and broken setups

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -1,0 +1,3 @@
+OPENAI_API_KEY=your-api-key
+DEEPSEEK_API_KEY=your-api-key
+HUGGINGFACE_HUB_TOKEN=your-hugging-face-token

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "pathfinder"]
 	path = pathfinder
-	url = git@github.com:giorgiopiatti/pathfinder.git
+	url = https://github.com/giorgiopiatti/PathFinder.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 wandb==0.16.1
+numpy==1.24.4
 pettingzoo==1.24.2
 pytest==7.4.3
 pydantic

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ dash
 dash-bootstrap-components
 lifelines
 statsmodels
-dash-mantine-components
+dash-mantine-components==0.12.1
 python-dotenv
 flask_caching
 sentence_transformers

--- a/setup.sh
+++ b/setup.sh
@@ -13,4 +13,4 @@ pip3 install bitsandbytes
 pip3 install -r requirements.txt
 
 
-pip3 transformers==4.39.3
+pip3 install transformers==4.39.3

--- a/setup.sh
+++ b/setup.sh
@@ -7,10 +7,10 @@ conda install conda-forge::weasyprint -y
 conda install -c conda-forge python-kaleido -y
 
 pip3 install -r pathfinder/requirements.txt
-pip3 install autogptq
+pip3 install auto-gptq
 pip3 install bitsandbytes
 
 pip3 install -r requirements.txt
 
 
-pip3 install transformers==4.39.3
+pip3 install transformers

--- a/simulation/analysis/preprocessing.py
+++ b/simulation/analysis/preprocessing.py
@@ -48,7 +48,7 @@ def columns_non_relevant(df):
     return columns_with_variability
 
 
-def get_summary_runs(subset_name, WANDB=True):
+def get_summary_runs(subset_name, WANDB=False):
     # Collect all runs data
 
     acc = []
@@ -123,11 +123,9 @@ def get_summary_runs(subset_name, WANDB=True):
                 )
             )
     else:
-        base_path = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)),
-            "../results",
-            subset_name,
-        )
+        base_path = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "results", subset_name)
+)
         for group in os.listdir(base_path):
             group_path = os.path.join(base_path, group)
             if not os.path.isdir(group_path):


### PR DESCRIPTION
- Fixed the path to the submodule in .gitattributes to ensure correct configuration.
- Updated the submodule to point to the latest commit.
- Updated version of dash-mantine-components in requirements.txt
- Fix default WANB parameter to False in order to use the default simulations/results directory
- Fix forgotten 'install' for transformers in setup.sh

These changes resolve a misconfiguration issue causing incorrect setup and ensure the submodule works seamlessly with the main repository.