### PR TITLE
Fix Model Assignment During Persona Deliberation in ‘Restaurant’ location (MultiLLM)

### DIFF
--- a/simulation/persona/persona.py
+++ b/simulation/persona/persona.py
@@ -81,10 +81,10 @@ class PersonaAgent:
         self.other_personas: dict[str, PersonaAgent] = {}
         self.other_personas_from_id: dict[str, PersonaAgent] = {}
 
-    def init_persona(self, agent_id: int, identity: PersonaIdentity, social_graph):
+    def init_persona(self, agent_id: int, identity: PersonaIdentity, social_graph, model: ModelWandbWrapper = None):
         self.agent_id = agent_id
         self.identity = identity
-
+        self.model = model
         self.scratch = Scratch(f"{self.base_path}")
 
     def add_reference_to_other_persona(self, persona: "PersonaAgent"):

--- a/simulation/scenarios/fishing/agents/persona_v3/cognition/converse.py
+++ b/simulation/scenarios/fishing/agents/persona_v3/cognition/converse.py
@@ -76,6 +76,7 @@ class FishingConverseComponent(ConverseComponent):
         max_conversation_steps = self.cfg.max_conversation_steps  # TODO
 
         current_persona = self.persona.identity
+        current_model = self.model
 
         while True:
             focal_points = [current_context]
@@ -95,7 +96,7 @@ class FishingConverseComponent(ConverseComponent):
                 )
 
             utterance, end_conversation, next_name, h = prompt(
-                self.model,
+                current_model,
                 current_persona,
                 target_personas,
                 focal_points,
@@ -112,6 +113,7 @@ class FishingConverseComponent(ConverseComponent):
                 break
             else:
                 current_persona = self.other_personas[next_name].identity
+                current_model = self.other_personas[next_name].model
 
         summary_conversation, h = prompt_summarize_conversation_in_one_sentence(
             self.model_framework, self.conversation_render(current_conversation)

--- a/simulation/scenarios/fishing/run.py
+++ b/simulation/scenarios/fishing/run.py
@@ -68,8 +68,12 @@ def run(
     agent_name_to_id["framework"] = "framework"
     agent_id_to_name = {v: k for k, v in agent_name_to_id.items()}
 
-    for persona in personas:
-        personas[persona].init_persona(persona, identities[persona], social_graph=None)
+    for i, persona in enumerate(personas):
+        personas[persona].init_persona(persona,
+                                       identities[persona],
+                                       social_graph=None,
+                                       model = wrappers[i],
+    )
 
     for persona in personas:
         for other_persona in personas:

--- a/simulation/scenarios/pollution/agents/persona_v3/cognition/converse.py
+++ b/simulation/scenarios/pollution/agents/persona_v3/cognition/converse.py
@@ -56,6 +56,7 @@ class PollutionConverseComponent(ConverseComponent):
         max_conversation_steps = self.cfg.max_conversation_steps  # TODO
 
         current_persona = self.persona.identity
+        current_model = self.model
 
         while True:
             focal_points = [current_context]
@@ -75,7 +76,7 @@ class PollutionConverseComponent(ConverseComponent):
                 )
 
             utterance, end_conversation, next_name, h = prompt(
-                self.model,
+                current_model,
                 current_persona,
                 target_personas,
                 focal_points,
@@ -92,6 +93,7 @@ class PollutionConverseComponent(ConverseComponent):
                 break
             else:
                 current_persona = self.other_personas[next_name].identity
+                current_model = self.other_personas[next_name].model
 
         summary_conversation, h = prompt_summarize_conversation_in_one_sentence(
             self.model_framework, self.conversation_render(current_conversation)

--- a/simulation/scenarios/pollution/run.py
+++ b/simulation/scenarios/pollution/run.py
@@ -62,8 +62,12 @@ def run(
     agent_name_to_id["framework"] = "framework"
     agent_id_to_name = {v: k for k, v in agent_name_to_id.items()}
 
-    for persona in personas:
-        personas[persona].init_persona(persona, identities[persona], social_graph=None)
+    for i, persona in enumerate(personas):
+        personas[persona].init_persona(persona,
+                                       identities[persona],
+                                       social_graph=None,
+                                       model = wrappers[i],
+        )
 
     for persona in personas:
         for other_persona in personas:

--- a/simulation/scenarios/sheep/agents/persona_v3/cognition/converse.py
+++ b/simulation/scenarios/sheep/agents/persona_v3/cognition/converse.py
@@ -56,6 +56,7 @@ class SheepConverseComponent(ConverseComponent):
         max_conversation_steps = self.cfg.max_conversation_steps  # TODO
 
         current_persona = self.persona.identity
+        current_model = self.model
 
         while True:
             focal_points = [current_context]
@@ -75,7 +76,7 @@ class SheepConverseComponent(ConverseComponent):
                 )
 
             utterance, end_conversation, next_name, h = prompt(
-                self.model,
+                current_model,
                 current_persona,
                 target_personas,
                 focal_points,
@@ -92,6 +93,7 @@ class SheepConverseComponent(ConverseComponent):
                 break
             else:
                 current_persona = self.other_personas[next_name].identity
+                current_model = self.other_personas[next_name].model
 
         summary_conversation, h = prompt_summarize_conversation_in_one_sentence(
             self.model_framework, self.conversation_render(current_conversation)

--- a/simulation/scenarios/sheep/run.py
+++ b/simulation/scenarios/sheep/run.py
@@ -62,8 +62,12 @@ def run(
     agent_name_to_id["framework"] = "framework"
     agent_id_to_name = {v: k for k, v in agent_name_to_id.items()}
 
-    for persona in personas:
-        personas[persona].init_persona(persona, identities[persona], social_graph=None)
+    for i, persona in enumerate(personas):
+        personas[persona].init_persona(persona,
+                                       identities[persona],
+                                       social_graph=None,
+                                       model = wrappers[i],
+        )
 
     for persona in personas:
         for other_persona in personas:


### PR DESCRIPTION
- Issue: During deliberations in the “restaurant” location, despite changing the names of the agents, the code would always reference the same model (self.model) because it was not being updated to reflect the next persona’s model.

- Solution: Updated the init_persona() method to properly assign and retain the model corresponding to each persona, ensuring that the correct model is used for each agent during deliberations.